### PR TITLE
document support for reservation config in profiles.yml

### DIFF
--- a/website/docs/docs/core/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/core/connect-data-platform/bigquery-setup.md
@@ -318,7 +318,7 @@ my-profile:
       reservation: projects/abc-123/locations/US/reservations/my-reservation
 ```
 If not specified, BigQuery will use the default reservation assignment associated with the project, folder, or organization. The reservation must be located in the same region as the query, and the authenticated account must have permission to use the specified reservation.
-See official docs for [Workload management using reservations](https://cloud.google.com/bigquery/docs/reservations-workload-managemen)
+See official docs for [Workload management using reservations](https://cloud.google.com/bigquery/docs/reservations-workload-management)
 
 ### Maximum Bytes Billed
 

--- a/website/docs/docs/core/connect-data-platform/bigquery-setup.md
+++ b/website/docs/docs/core/connect-data-platform/bigquery-setup.md
@@ -301,6 +301,25 @@ my-profile:
       location: US # Optional, one of US or EU, or a regional location
 ```
 
+### Reservations
+
+BigQuery now lets you choose which reservation a query should use at runtime. If you set `reservation` in your BigQuery profile, dbt will pass it to the job config; if omitted, BigQuery’s default assignment rules apply.
+Example:
+
+```yaml
+my-profile:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: oauth
+      project: abc-123
+      dataset: my_dataset
+      reservation: projects/abc-123/locations/US/reservations/my-reservation
+```
+If not specified, BigQuery will use the default reservation assignment associated with the project, folder, or organization. The reservation must be located in the same region as the query, and the authenticated account must have permission to use the specified reservation.
+See official docs for [Workload management using reservations](https://cloud.google.com/bigquery/docs/reservations-workload-managemen)
+
 ### Maximum Bytes Billed
 
 When a `maximum_bytes_billed` value is configured for a BigQuery profile,


### PR DESCRIPTION
## What are you changing in this pull request and why?

This PR adds documentation for the new reservation config option in BigQuery profiles, introduced in https://github.com/dbt-labs/dbt-adapters/pull/1229

BigQuery now supports specifying a reservation at query runtime, and this change allows dbt users to optionally configure a reservation in their profiles.yml. 

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additiona checklist items to the list if additional checks need to happen before the PR is merged, such as:
-->
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/dbt-cloud-release-notes).).
- [ ] This documentation update is contingent on the acceptance of https://github.com/dbt-labs/dbt-adapters/pull/1229 
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->